### PR TITLE
Style right pods

### DIFF
--- a/_partials/kits/_body.kit
+++ b/_partials/kits/_body.kit
@@ -1,5 +1,6 @@
     <div class="row">
       <div class="column content-article">
+          <!-- @import 'components/right-pod.kit' -->
     	  <p>Aenean at eros orci, id varius nibh. Quisque lacinia lacinia tortor  malesuada tempor. Integer sit amet mauris urna. Cras vel nibh cursus  quam tempus tincidunt quis sit amet velit. Proin consequat urna non  lectus tincidunt convallis. Nam justo enim, porttitor nec interdum at,  vehicula vitae dolor. Nam vel risus odio, at hendrerit libero.</p>
     	  <p>&nbsp;</p>
     	  <p>Sed vel magna lectus, quis scelerisque massa. Duis interdum adipiscing  ultricies. Etiam venenatis lacus in nulla auctor et cursus ipsum  fringilla. Mauris id urna metus, a commodo eros. Aliquam mattis  fermentum tellus, ac fermentum mi lacinia ut. Nullam tincidunt lorem in  mi feugiat luctus.</p>
@@ -27,7 +28,6 @@
 
       </div>
       <div class="column content-aside">
-        <!-- @import 'components/right-pod.kit' -->
         <!-- @import 'components/_primary-pods.kit'-->
       </div>
     </div>

--- a/_partials/scss/_config.scss
+++ b/_partials/scss/_config.scss
@@ -20,6 +20,7 @@ $rem-px-fallback: true;
 $badger-red: #970D0E;
 $uw-gold: #E7D9C1;
 $smph-tan: #EDE9D4;
+$smph-tan-dark: darken($smph-tan, 15%);
 $smph-gold: #C7AB4C;
 
 //Themes

--- a/_partials/scss/base/_reset.scss
+++ b/_partials/scss/base/_reset.scss
@@ -108,6 +108,10 @@ select::-ms-value {
 	color: currentColor;/* Edge 12+, Internet Explorer 11- */
 }
 
+img {
+	max-width: 100%;
+}
+
 //ul {
 //	list-style: none;
 //}
@@ -117,12 +121,3 @@ select::-ms-value {
 //	margin: 0;
 //	padding: 0;
 //}
-
-#mainContainer ul {
-	list-style: disc;
-	@include type-space(margin, 1 0 1 1.5);
-}
-
-#mainContainer li {
-	@include type-space(padding, 0 0 .5);
-}

--- a/_partials/scss/components/_left-nav.scss
+++ b/_partials/scss/components/_left-nav.scss
@@ -21,7 +21,7 @@
 }
 
 .leftNav-items > li {
-	border-bottom: 1px solid darken($smph-tan, 15%);
+	border-bottom: 1px solid $smph-tan-dark;
 	padding: 0;
 	margin: 0;
 
@@ -37,7 +37,7 @@
 		overflow-wrap: break-word;
 		text-overflow: ellipsis;
 		max-width: 32.5%;
-		border-top: 1px solid darken($smph-tan, 15%);
+		border-top: 1px solid $smph-tan-dark;
 		margin-bottom: -1px;
 		min-height: 44px;
 	}
@@ -49,7 +49,7 @@
 }
 
 .leftNav-items > li:first-child {
-	border-top: 1px solid darken($smph-tan, 15%);
+	border-top: 1px solid $smph-tan-dark;
 }
 
 .leftNav-items a {

--- a/_partials/scss/components/_pods.scss
+++ b/_partials/scss/components/_pods.scss
@@ -39,3 +39,32 @@
 	@include type-space(padding-bottom, 1);
 	vertical-align: middle;
 }
+
+.rightPod {
+	@extend %border-box;
+	float: right;
+	min-width: 189px;
+	@extend %one_third;
+	@include type-space(margin, 0 0 1 .5);
+	@include type-space(padding, 1);
+	border: 1px solid $smph-tan-dark;
+
+	@include media-query('max-width' 330px) {
+		width: 100%;
+		float: none;
+		margin-left: auto;
+		margin-right: auto;
+		min-width: none;
+	}
+
+}
+
+.rightPod p,
+.rightPod li {
+	@include type-space(padding-bottom, .5);
+}
+
+.rightPod ul {
+	list-style: none;
+	margin: 0;
+}

--- a/_partials/scss/globals/_mixins.scss
+++ b/_partials/scss/globals/_mixins.scss
@@ -40,7 +40,8 @@
 
 //Space and sizing mixin
 //Creates rem values based on the base-line-height and the grid-gutters
-
+// $multipliers can be a space-separated list
+// adding
 @mixin type-space($properties, $multipliers.../*important*/) {
 
 	$important: false;
@@ -53,14 +54,12 @@
 		$important_check: nth($multipliers, -1);
 
 		//If last value is $important, then set the $multiplier and $important accordingly
-		@if type-of($important_check) == bool {
-			$important: $important_check;
+		@if (type-of($important_check) != number) {
+			$important: if($important_check, true, false);
 			$multiplier: nth($multipliers, 1);
 			$m-length: 1;
 		}
 	}
-
-	//If multiplier is only 1 value, then do expected stuff
 
 	@each $property in $properties {
 		$values: null;
@@ -87,6 +86,7 @@
 //Sizing mixin
 //Create multiples based on the base-font-size with an upper limit
 // Different from type-space() where all values are based on the grid
+// Upper limit used to prevent crazy scales for larger font-sizes
 @mixin type-scale($properties, $multipliers, $upper-limit: 0) {
 
 	@if unit($upper-limit) == "" {
@@ -111,6 +111,7 @@
 
 //Modern clearfix
 @mixin clearfix(){
+	*zoom: 1;
 
 	&:after {
 		content: "";
@@ -121,6 +122,8 @@
 }
 
 //Standard theme box-shadow
+//larger numbers imply more depth
+//$z accepts decimals for more incremental depth
 @mixin shadow($z: 1, $inset: false) {
 	$inset: 	if($inset, 'inset', null);
 	$base:		if($inset, 5, 3);

--- a/_partials/scss/utilities/_overrides.scss
+++ b/_partials/scss/utilities/_overrides.scss
@@ -11,11 +11,11 @@
     border: 0;
     clip: rect(0 0 0 0);
     height: 1px;
+    width: 1px;
     margin: -1px;
     overflow: hidden;
     padding: 0;
     position: absolute;
-    width: 1px;
 	transition: all .15s ease-out;
 }
 
@@ -33,6 +33,17 @@
     overflow: visible;
     position: static;
     width: auto;
+}
+
+
+.imgRight {
+    float: right;
+    @include type-space(margin-left, .5);
+}
+
+.imgLeft {
+    float: left;
+    @include type-space(margin-right, .5);
 }
 
 .clearFloat {
@@ -54,6 +65,24 @@
 }
 .inline-block {
 	display: inline-block !important;
+    *display: inline !important; /* IE 7 fix */
+    *zoom: 1;
+}
+
+.padL10 {
+	@include type-space(padding-left, 1, important);
+}
+.padR10 {
+    @include type-space(padding-right, 1, important);
+}
+.padT10 {
+    @include type-space(padding-top, 1, important);
+}
+.padB10 {
+    @include type-space(padding-bottom, 1, important);
+}
+.padN {
+    padding: 0 !important;
 }
 
 @include media-query('bigs') {
@@ -72,6 +101,22 @@
 	.bigs-inline-block {
 		display: inline-block !important;
 	}
+
+    .bigs-padL10 {
+    	@include type-space(padding-left, 1, important);
+    }
+    .bigs-padR10 {
+        @include type-space(padding-right, 1, important);
+    }
+    .bigs-padT10 {
+        @include type-space(padding-top, 1, important);
+    }
+    .bigs-padB10 {
+        @include type-space(padding-bottom, 1, important);
+    }
+    .bigs-padN {
+        padding: 0 !important;
+    }
 }
 
 @include media-query('smalls') {
@@ -90,9 +135,59 @@
 	.smalls-inline-block {
 		display: inline-block !important;
 	}
+
+    .smalls-padL10 {
+    	@include type-space(padding-left, 1, important);
+    }
+    .smalls-padR10 {
+        @include type-space(padding-right, 1, important);
+    }
+    .smalls-padT10 {
+        @include type-space(padding-top, 1, important);
+    }
+    .smalls-padB10 {
+        @include type-space(padding-bottom, 1, important);
+    }
+    .smalls-padN {
+        padding: 0 !important;
+    }
 }
 
-/* IE8- pollyfill*/
-.lt-ie9 .bigs-hide {
-	display: none !important;
+/* IE8 (and below) safeguards */
+.lt-ie9 {
+    .bigs-hide {
+		display: none !important;
+	}
+	.bigs-inline {
+		display: inline !important;
+	}
+	.bigs-table {
+		display: table !important;
+	}
+	.bigs-block {
+		display: block !important;
+	}
+	.bigs-inline-block {
+		display: inline-block !important;
+        *display: inline !important; /* IE 7 fix */
+        *zoom: 1;
+	}
+    .bigs-hide {
+    	display: none !important;
+    }
+    .bigs-padL10 {
+    	padding-left: $grid-gutter/2 !important;
+    }
+    .bigs-padR10 {
+        padding-right: $grid-gutter/2 !important;
+    }
+    .bigs-padT10 {
+        padding-top: $grid-gutter/2 !important;
+    }
+    .bigs-padB10 {
+        padding-bottom: $grid-gutter/2 !important;
+    }
+    .bigs-padN {
+        padding: 0 !important;
+    }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,7 @@ var paths = {
 };
 
 //Files to watch to keep browser preview up to date
-var browser_sync_watch = ['./style/*.css', './javascript/**', './*.html'];
+var browser_sync_watch = ['./style/*.css', './javascript/**/*.js', './*.html'];
 
 
 /******************************/
@@ -130,15 +130,17 @@ gulp.task('js', function(){
 		.pipe(plumber({errorHandler: _error}))
 		.pipe(include())
 		//Check if files are changed only if minification is not required
-		.pipe(gIf(!_minify,
+		.pipe(gIf(! _minify,
 			changed(paths.js.dest)
 		))
-		.pipe(gIf(_minify,
+		.pipe(gIf( _minify,
 			uglify({preserveComments: 'some'})
 		))
-		.pipe(gIf(_minify,
+		.pipe(gIf( _minify,
 			rename(function(path){
-				//Add -min to uglified files
+				// Add .min to uglified files
+				// Make sure we don't duplicate .min
+				path.basename = path.basename.replace('.min', '');
 				path.basename = path.basename + '.min';
 			})
 		))

--- a/index.html
+++ b/index.html
@@ -99,6 +99,19 @@
       <div class="column content-main">
         <div class="row">
           <div class="column content-article">
+            <div class="rightPod">
+              <div class="innerRight">
+                <p><strong>UW-Madison Office of Clinical Trials<br />
+	  </strong></p>
+                <p><a href="#" target="_blank">www.clinicaltrials.wisc.edu</a></p>
+                <p><a href="#" target="_blank">How to Volunteer</a></p>
+                <p><a href="#" target="_blank">Frequently Asked Questions (FAQs) for Volunteers</a></p>
+                <p><a href="http://www.clinicaltrials.wisc.edu/public/pub_studies.htm" target="_blank">Currently Enrolling Studies<br />
+	  </a><strong><br />
+	  Cancer Clinical Trials</strong></p>
+                <p><a href="#" target="_blank">UW Carbone Cancer Center Clinical Trials</a></p>
+              </div>
+            </div>
             <p>Aenean at eros orci, id varius nibh. Quisque lacinia lacinia tortor malesuada tempor. Integer sit amet mauris urna. Cras vel nibh cursus quam tempus tincidunt quis sit amet velit. Proin consequat urna non lectus tincidunt convallis. Nam justo
               enim, porttitor nec interdum at, vehicula vitae dolor. Nam vel risus odio, at hendrerit libero.</p>
             <p>&nbsp;</p>
@@ -147,19 +160,6 @@
             </div>
           </div>
           <div class="column content-aside">
-            <div class="rightPod">
-              <div class="innerRight">
-                <p><strong>UW-Madison Office of Clinical Trials<br />
-	  </strong></p>
-                <p><a href="#" target="_blank">www.clinicaltrials.wisc.edu</a></p>
-                <p><a href="#" target="_blank">How to Volunteer</a></p>
-                <p><a href="#" target="_blank">Frequently Asked Questions (FAQs) for Volunteers</a></p>
-                <p><a href="http://www.clinicaltrials.wisc.edu/public/pub_studies.htm" target="_blank">Currently Enrolling Studies<br />
-	  </a><strong><br />
-	  Cancer Clinical Trials</strong></p>
-                <p><a href="#" target="_blank">UW Carbone Cancer Center Clinical Trials</a></p>
-              </div>
-            </div>
             <div class="primaryPod">
               <h2 class="primaryPod-head">Research &amp; News</h2>
               <ul class="primaryPod-body">

--- a/style/main.css
+++ b/style/main.css
@@ -129,15 +129,8 @@ select::-ms-value {
   /* Edge 12+, Internet Explorer 11- */
 }
 
-#mainContainer ul {
-  list-style: disc;
-  margin: 13px 0 13px 30px;
-  margin: 1.18182rem 0 1.18182rem 2.72727rem;
-}
-
-#mainContainer li {
-  padding: 0 0 6.5px;
-  padding: 0 0 0.59091rem;
+img {
+  max-width: 100%;
 }
 
 h1 {
@@ -294,7 +287,7 @@ h6 a:hover {
   width: 75%;
 }
 
-.c-third {
+.c-third, .rightPod {
   width: 33.33333%;
 }
 
@@ -494,7 +487,7 @@ h6 a:hover {
   }
 }
 
-.row, .row-middle, .row-skinny, .column, .page, .leftNav-items a, .form-grid input,
+.row, .row-middle, .row-skinny, .column, .page, .leftNav-items a, .rightPod, .form-grid input,
 .form-grid textarea,
 .form-grid select, .top-nav-button, .searchBox, .footer, .footerColumn, .footer .linkImage {
   -webkit-box-sizing: border-box;
@@ -802,6 +795,37 @@ h6 a:hover {
   padding-bottom: 13px;
   padding-bottom: 1.18182rem;
   vertical-align: middle;
+}
+
+.rightPod {
+  float: right;
+  min-width: 189px;
+  margin: 0 0 13px 10px;
+  margin: 0 0 1.18182rem 0.90909rem;
+  padding: 13px;
+  padding: 1.18182rem;
+  border: 1px solid #d6cd9e;
+}
+
+@media only screen and (max-width: 330px) {
+  .rightPod {
+    width: 100%;
+    float: none;
+    margin-left: auto;
+    margin-right: auto;
+    min-width: none;
+  }
+}
+
+.rightPod p,
+.rightPod li {
+  padding-bottom: 6.5px;
+  padding-bottom: 0.59091rem;
+}
+
+.rightPod ul {
+  list-style: none;
+  margin: 0;
 }
 
 .form-grid > .column {
@@ -1178,6 +1202,7 @@ h6 a:hover {
 
 .navBar {
   background-color: #970D0E;
+  *zoom: 1;
 }
 
 .navBar:after {
@@ -1506,11 +1531,11 @@ h6 a:hover {
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
+  width: 1px;
   margin: -1px;
   overflow: hidden;
   padding: 0;
   position: absolute;
-  width: 1px;
   -webkit-transition: all .15s ease-out;
           transition: all .15s ease-out;
 }
@@ -1528,6 +1553,18 @@ h6 a:hover {
   overflow: visible;
   position: static;
   width: auto;
+}
+
+.imgRight {
+  float: right;
+  margin-left: 10px;
+  margin-left: 0.90909rem;
+}
+
+.imgLeft {
+  float: left;
+  margin-right: 10px;
+  margin-right: 0.90909rem;
 }
 
 .clearFloat {
@@ -1553,6 +1590,33 @@ h6 a:hover {
 
 .inline-block {
   display: inline-block !important;
+  *display: inline !important;
+  /* IE 7 fix */
+  *zoom: 1;
+}
+
+.padL10 {
+  padding-left: 20px !important;
+  padding-left: 1.81818rem !important;
+}
+
+.padR10 {
+  padding-right: 20px !important;
+  padding-right: 1.81818rem !important;
+}
+
+.padT10 {
+  padding-top: 13px !important;
+  padding-top: 1.18182rem !important;
+}
+
+.padB10 {
+  padding-bottom: 13px !important;
+  padding-bottom: 1.18182rem !important;
+}
+
+.padN {
+  padding: 0 !important;
 }
 
 @media only screen and (min-width: 675px) {
@@ -1570,6 +1634,25 @@ h6 a:hover {
   }
   .bigs-inline-block {
     display: inline-block !important;
+  }
+  .bigs-padL10 {
+    padding-left: 20px !important;
+    padding-left: 1.81818rem !important;
+  }
+  .bigs-padR10 {
+    padding-right: 20px !important;
+    padding-right: 1.81818rem !important;
+  }
+  .bigs-padT10 {
+    padding-top: 13px !important;
+    padding-top: 1.18182rem !important;
+  }
+  .bigs-padB10 {
+    padding-bottom: 13px !important;
+    padding-bottom: 1.18182rem !important;
+  }
+  .bigs-padN {
+    padding: 0 !important;
   }
 }
 
@@ -1589,9 +1672,71 @@ h6 a:hover {
   .smalls-inline-block {
     display: inline-block !important;
   }
+  .smalls-padL10 {
+    padding-left: 20px !important;
+    padding-left: 1.81818rem !important;
+  }
+  .smalls-padR10 {
+    padding-right: 20px !important;
+    padding-right: 1.81818rem !important;
+  }
+  .smalls-padT10 {
+    padding-top: 13px !important;
+    padding-top: 1.18182rem !important;
+  }
+  .smalls-padB10 {
+    padding-bottom: 13px !important;
+    padding-bottom: 1.18182rem !important;
+  }
+  .smalls-padN {
+    padding: 0 !important;
+  }
 }
 
-/* IE8- pollyfill*/
+/* IE8 (and below) safeguards */
 .lt-ie9 .bigs-hide {
   display: none !important;
+}
+
+.lt-ie9 .bigs-inline {
+  display: inline !important;
+}
+
+.lt-ie9 .bigs-table {
+  display: table !important;
+}
+
+.lt-ie9 .bigs-block {
+  display: block !important;
+}
+
+.lt-ie9 .bigs-inline-block {
+  display: inline-block !important;
+  *display: inline !important;
+  /* IE 7 fix */
+  *zoom: 1;
+}
+
+.lt-ie9 .bigs-hide {
+  display: none !important;
+}
+
+.lt-ie9 .bigs-padL10 {
+  padding-left: 10px !important;
+}
+
+.lt-ie9 .bigs-padR10 {
+  padding-right: 10px !important;
+}
+
+.lt-ie9 .bigs-padT10 {
+  padding-top: 10px !important;
+}
+
+.lt-ie9 .bigs-padB10 {
+  padding-bottom: 10px !important;
+}
+
+.lt-ie9 .bigs-padN {
+  padding: 0 !important;
 }


### PR DESCRIPTION
* Added styling for right pods
  * Deprecated the styling for innerRight, since border-box achieves the same goal.
* Added image float styles (imgRight, imgLeft)
* Added padding override styles
* Fixed a bug in the type-space mixin
* Added IMG tag max-width styles for better responsiveness

* Fixed a bug in gulp's js minification task